### PR TITLE
fix: edge-auto repositories

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -33,7 +33,7 @@ repositories:
     version: main
   individual_params:
     type: git
-    url: https://github.com/tier4/perception_ecu_individual_params.git  # (TODO) rename repo
+    url: https://github.com/tier4/edge_auto_individual_params.git
     version: main
   calibration_tools:
     type: git


### PR DESCRIPTION
## Related Links

https://github.com/tier4/edge-auto-jetson/pull/24

## Description

I changed repo names according to renaming `perception_ecu` -> `edge_auto`.

## Review Procedure

```sh
vcs import src < autoware.repos
```

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
