### PR TITLE
fix(playbooks/edge_auto.yaml): correct handling of prompt result

### DIFF
--- a/ansible/playbooks/edge_auto.yaml
+++ b/ansible/playbooks/edge_auto.yaml
@@ -60,8 +60,8 @@
     - role: autoware.dev_env.ros2_domain_id
     - role: autoware.dev_env.cyclonedds
     - role: autoware.dev_env.ptp4l_host
-      when: prompt_configure_network
+      when: prompt_configure_network == 'y'
     - role: autoware.dev_env.enlarge_rx_ring_buffer
-      when: prompt_configure_network
+      when: prompt_configure_network == 'y'
     - role: autoware.dev_env.netplan
-      when: prompt_configure_network
+      when: prompt_configure_network == 'y'


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Currently, I found that the prompt result regarding network configuration is not handled correctly. this PR fixes the handling.

## Related links
- https://github.com/tier4/edge-auto-jetson/pull/30

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
