### PR TITLE
fix(autoware.repos): update transport drivers branch

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -46,7 +46,7 @@ repositories:
   transport_drivers:
     type: git
     url: https://github.com/MapIV/transport_drivers.git
-    version: tcp
+    version: boost
   lidartag:
     type: git
     url: https://github.com/tier4/LiDARTag.git


### PR DESCRIPTION
## Description

This PR updates to the correct branch of the `transport_drivers` package in `autoware.repos`.

## Tests performed

Not applicable.

## Effects on system behavior

This removes a build error caused by renaming of the transport driver package to prevent naming collisions in environments where the driver package already exists. See https://github.com/tier4/nebula/pull/46 for details.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
