### PR TITLE
fix: update list of dependencies in autoware.repos

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -1,105 +1,106 @@
 repositories:
-  autoware.universe:
-    type: git
-    url: https://github.com/autowarefoundation/autoware.universe.git
-    version: main
-  autoware_common:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_common.git
-    version: main
-  autoware_msgs:
+  # core
+  core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
     version: main
-  autoware_adapi_msgs:
+  core/autoware_adapi_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
     version: main
-  autoware_auto_msgs:
+  core/autoware_common:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_common.git
+    version: main
+  core/external/autoware_auto_msgs:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
     version: tier4/main
-  tier4_autoware_msgs:
+  # universe
+  universe/autoware.universe:
     type: git
-    url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: tier4/universe
-  launcher:
-    type: git
-    url: https://github.com/tier4/edge_auto_launch.git
+    url: https://github.com/autowarefoundation/autoware.universe.git
     version: main
-  individual_params:
-    type: git
-    url: https://github.com/tier4/edge_auto_individual_params.git
-    version: main
-  calibration_tools:
-    type: git
-    url: https://github.com/tier4/CalibrationTools.git
-    version: tier4/universe
-  nebula:
-    type: git
-    url: https://github.com/tier4/nebula.git
-    version: main
-  transport_drivers:
-    type: git
-    url: https://github.com/MapIV/transport_drivers.git
-    version: boost
-  lidartag:
-    type: git
-    url: https://github.com/tier4/LiDARTag.git
-    version: humble
-  lidartag_msgs:
-    type: git
-    url: https://github.com/tier4/LiDARTag_msgs.git
-    version: tier4/universe
-  apriltag_msgs:
-    type: git
-    url: https://github.com/christianrauch/apriltag_msgs.git
-    version: 2.0.0
-  apriltag_ros:
-    type: git
-    url: https://github.com/christianrauch/apriltag_ros.git
-    version: e814e9e5d5f1bfb60a4aa685d30977c632bbc540
-  ros2_numpy:
-    type: git
-    url: https://github.com/Box-Robotics/ros2_numpy.git
-    version: humble
-  image_pipeline:
-    type: git
-    url: https://github.com/tier4/image_pipeline.git
-    version: 47964112293eb19f9f57254b2e6b68706954cc63
-  external/muSSP:
-      type: git
-      url: https://github.com/tier4/muSSP.git
-      version: tier4/main
-  external/ndt_omp:
-      type: git
-      url: https://github.com/tier4/ndt_omp.git
-      version: tier4/main
-  external/eagleye:
-      type: git
-      url: https://github.com/MapIV/eagleye.git
-      version: autoware-main
-  external/morai_msgs:
-      type: git
-      url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
-      version: main
-  external/autoware_launch:
-      type: git
-      url: https://github.com/autowarefoundation/autoware_launch.git
-      version: main
-  external/transport_drivers:
-      type: git
-      url: https://github.com/MapIV/transport_drivers
-      version: boost
-  external/rtklib_ros_bridge:
-    type: git
-    url: https://github.com/MapIV/rtklib_ros_bridge.git
-    version: ros2-v0.1.0
-  external/llh_converter:
-    type: git
-    url: https://github.com/MapIV/llh_converter.git
-    version: ros2
-  external/tier4_ad_api_adaptor: # TODO(TIER IV): Improve design/code and transfer to AWF
+  universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Improve design/code and transfer to AWF
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
     version: tier4/universe
+  universe/external/tier4_autoware_msgs:
+    type: git
+    url: https://github.com/tier4/tier4_autoware_msgs.git
+    version: tier4/universe
+  universe/external/morai_msgs:
+    type: git
+    url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
+    version: main
+  universe/external/muSSP:
+    type: git
+    url: https://github.com/tier4/muSSP.git
+    version: tier4/main
+  universe/external/ndt_omp:
+    type: git
+    url: https://github.com/tier4/ndt_omp.git
+    version: tier4/main
+  universe/external/eagleye:
+    type: git
+    url: https://github.com/MapIV/eagleye.git
+    version: autoware-main
+  universe/external/rtklib_ros_bridge:
+    type: git
+    url: https://github.com/MapIV/rtklib_ros_bridge.git
+    version: ros2-v0.1.0
+  universe/external/llh_converter:
+    type: git
+    url: https://github.com/MapIV/llh_converter.git
+    version: ros2
+  # launcher
+  launcher/autoware_launch:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_launch.git
+    version: main
+  # sensor_component
+  sensor_component/external/nebula:
+    type: git
+    url: https://github.com/tier4/nebula.git
+    version: main
+  sensor_component/external/transport_drivers:
+    type: git
+    url: https://github.com/MapIV/transport_drivers.git
+    version: boost
+  # edge auto
+  edge_auto/launcher:
+    type: git
+    url: https://github.com/tier4/edge_auto_launch.git
+    version: main
+  edge_auto/individual_params:
+    type: git
+    url: https://github.com/tier4/edge_auto_individual_params.git
+    version: main
+  dependencies/calibration_tools:
+    type: git
+    url: https://github.com/tier4/CalibrationTools.git
+    version: tier4/universe
+  dependencies/lidartag:
+    type: git
+    url: https://github.com/tier4/LiDARTag.git
+    version: humble
+  dependencies/lidartag_msgs:
+    type: git
+    url: https://github.com/tier4/LiDARTag_msgs.git
+    version: tier4/universe
+  dependencies/apriltag_msgs:
+    type: git
+    url: https://github.com/christianrauch/apriltag_msgs.git
+    version: 2.0.0
+  dependencies/apriltag_ros:
+    type: git
+    url: https://github.com/christianrauch/apriltag_ros.git
+    version: e814e9e5d5f1bfb60a4aa685d30977c632bbc540
+  dependencies/ros2_numpy:
+    type: git
+    url: https://github.com/Box-Robotics/ros2_numpy.git
+    version: humble
+  dependencies/image_pipeline:
+    type: git
+    url: https://github.com/tier4/image_pipeline.git
+    version: 47964112293eb19f9f57254b2e6b68706954cc63

--- a/autoware.repos
+++ b/autoware.repos
@@ -19,10 +19,6 @@ repositories:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
     version: tier4/main
-  autoware.universe:
-    type: git
-    url: https://github.com/autowarefoundation/autoware.universe.git
-    version: main
   tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
@@ -71,3 +67,39 @@ repositories:
     type: git
     url: https://github.com/tier4/image_pipeline.git
     version: 47964112293eb19f9f57254b2e6b68706954cc63
+  external/muSSP:
+      type: git
+      url: https://github.com/tier4/muSSP.git
+      version: tier4/main
+  external/ndt_omp:
+      type: git
+      url: https://github.com/tier4/ndt_omp.git
+      version: tier4/main
+  external/eagleye:
+      type: git
+      url: https://github.com/MapIV/eagleye.git
+      version: autoware-main
+  external/morai_msgs:
+      type: git
+      url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
+      version: main
+  external/autoware_launch:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_launch.git
+      version: main
+  external/transport_drivers:
+      type: git
+      url: https://github.com/MapIV/transport_drivers
+      version: boost
+  external/rtklib_ros_bridge:
+    type: git
+    url: https://github.com/MapIV/rtklib_ros_bridge.git
+    version: ros2-v0.1.0
+  external/llh_converter:
+    type: git
+    url: https://github.com/MapIV/llh_converter.git
+    version: ros2
+  external/tier4_ad_api_adaptor: # TODO(TIER IV): Improve design/code and transfer to AWF
+    type: git
+    url: https://github.com/tier4/tier4_ad_api_adaptor.git
+    version: tier4/universe


### PR DESCRIPTION
## Description

Added required dependencies to autoware.repos file to successfully complete edge_auto tutorials without errors.

## Tests performed

Followed edge_auto tutorials to launch camera and lidar perception (lidar was simulated with rosbag). Confirmed that tutorials are completed without error and perception runs with reasonable-looking results.

## Effects on system behavior

edge_auto installation process, particularly the following code, now runs without errors:

```
rosdep update
rosdep install -y -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO

./build.sh
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
