### PR TITLE
Fix/update model download logic

### DIFF
--- a/ansible/playbooks/edge_auto.yaml
+++ b/ansible/playbooks/edge_auto.yaml
@@ -13,6 +13,10 @@
       prompt: |-
         [Warning] Do you want to configure the network? This configuration may overwrite the IP address of the specific network interface [y/N]
       private: false
+    - name: prompt_download_models
+      prompt: |-
+        [Warning] Do you want to download onnx models? [y/N]
+      private: false
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:
@@ -65,3 +69,5 @@
       when: prompt_configure_network == 'y'
     - role: autoware.dev_env.netplan
       when: prompt_configure_network == 'y'
+    - role: download_models
+      when: prompt_download_models == 'y'

--- a/ansible/roles/download_models/defaults/main.yaml
+++ b/ansible/roles/download_models/defaults/main.yaml
@@ -1,0 +1,1 @@
+data_dir: /opt/autoware/data

--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -1,9 +1,11 @@
 - name: Create data directory
+  become: true
   ansible.builtin.file:
     path: "{{ data_dir }}"
     state: directory
 
 - name: Create lidar_centerpoint directory inside {{ data_dir }}
+  become: true
   ansible.builtin.file:
     path: "{{ data_dir }}/lidar_centerpoint"
     mode: "755"

--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -1,0 +1,42 @@
+- name: Create data directory
+  ansible.builtin.file:
+    path: "{{ data_dir }}"
+    state: directory
+
+- name: Create lidar_centerpoint directory inside {{ data_dir }}
+  ansible.builtin.file:
+    path: "{{ data_dir }}/lidar_centerpoint"
+    mode: "755"
+    state: directory
+
+- name: Download lidar_centerpoint/pts_voxel_encoder_centerpoint.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/centerpoint/v2/pts_voxel_encoder_centerpoint.onnx
+    dest: "{{ data_dir }}/lidar_centerpoint/pts_voxel_encoder_centerpoint.onnx"
+    mode: "644"
+    checksum: sha256:dc1a876580d86ee7a341d543f8ade2ede7f43bd032dc5b44155b1f0175405764
+
+- name: Download lidar_centerpoint/pts_backbone_neck_head_centerpoint.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/centerpoint/v2/pts_backbone_neck_head_centerpoint.onnx
+    dest: "{{ data_dir }}/lidar_centerpoint/pts_backbone_neck_head_centerpoint.onnx"
+    mode: "644"
+    checksum: sha256:3fe7e128955646740c41a25be0c8f141d5a94594fe79d7405fe2a859e391542e
+
+- name: Download lidar_centerpoint/pts_voxel_encoder_centerpoint_tiny.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/centerpoint/v2/pts_voxel_encoder_centerpoint_tiny.onnx
+    dest: "{{ data_dir }}/lidar_centerpoint/pts_voxel_encoder_centerpoint_tiny.onnx"
+    mode: "644"
+    checksum: sha256:2c53465715c1fd2e9dc5727ef3fca74f4cdf0538f74286b0946e219d0ca5693b
+
+- name: Download lidar_centerpoint/pts_backbone_neck_head_centerpoint_tiny.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/centerpoint/v2/pts_backbone_neck_head_centerpoint_tiny.onnx
+    dest: "{{ data_dir }}/lidar_centerpoint/pts_backbone_neck_head_centerpoint_tiny.onnx"
+    mode: "644"
+    checksum: md5:e4658325b70222f7c3637fe00e586b82


### PR DESCRIPTION
## Description

This PR fixes edge-auto to align with Autoware Universe's new model download logic.

## Related Links
- https://github.com/autowarefoundation/autoware.universe/issues/3137

## Tests performed

Centerpoint and YOLOX from edge-auto and edge-auto-jetson respectively, were launched, and I confirmed that they were outputting predictions at the correct frequency (~10 Hz).

## Effects on system behavior

Previously, edge-auto's model downloading was broken by an update to Autoware Universe, such that YOLOX and Centerpoint would not be able to launch. This PR updates edge-auto to correctly download models under Autoware Universe's new scheme.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
