### PR TITLE
refactor: remove rosdep install command from build script and move to tutorials

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-rosdep install -y --from-paths `colcon list --packages-up-to edge_auto_launch -p` --ignore-src --skip-keys autoware_launch
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to edge_auto_launch

--- a/docs/tutorials/02_installation.md
+++ b/docs/tutorials/02_installation.md
@@ -52,6 +52,8 @@ Install ros package dependencies and build your ROS workspace.
 
 ```sh
 rosdep update
+rosdep install -y --from-paths `colcon list --packages-up-to edge_auto_launch -p` --ignore-src --skip-keys autoware_launch
+
 ./build.sh
 
 ...


### PR DESCRIPTION
## Description

This PR removes the `rosdep install` command from `build.sh` and places it in tutorials. This is because `rosdep install` often installs apt packages, requiring root privileges. If root privileges are given, the entire build script will run with root privileges which is undesirable.

## Tests performed

Not applicable.

## Effects on system behavior

Now `rosdep install` must be run manually instead of as a part of the build script

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
