### PR TITLE
chore: nebula single node support

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -39,10 +39,16 @@ repositories:
     type: git
     url: https://github.com/tier4/nebula.git
     version: main
+  # Fork of transport_drivers that enables reduction of copy operations
   transport_drivers:
     type: git
-    url: https://github.com/MapIV/transport_drivers.git
-    version: boost
+    url: https://github.com/mojomex/transport_drivers
+    version: mutable-buffer-in-udp-callback
+  # Continental compatible version of ROS 2 socket CAN
+  ros2_socketcan:
+    type: git
+    url: https://github.com/knzo25/ros2_socketcan
+    version: feat/continental_fd
   lidartag:
     type: git
     url: https://github.com/tier4/LiDARTag.git


### PR DESCRIPTION
## Description

This PR adds the dependencies required for the new Nebula version to `autoware.repos`, allowing for the transition to the new single-node Nebula architecture.

This is a **non-breaking change** and works with both the current, and the new single-node version of Nebula.

### Related PRs

**Other PRs depending on this PR:**

- tier4/edge_auto_launch#19
- tier4/nebula#176

## Tests performed

Compiled the project. Since this change is a mere dependency update with no behavior changes, no further testing was done.

## Effects on system behavior

None.

## Interface changes

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
