### PR TITLE
chore: freeze Nebula version and update dependency repo

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -82,11 +82,11 @@ repositories:
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
-    version: d9aaefc9a4c06f6dae86cd7ef22f6353f1379e4f
+    version: v0.0.1
   sensor_component/external/transport_drivers:
     type: git
-    url: https://github.com/MapIV/transport_drivers.git
-    version: e7e25ed52b58b3556fa8b0f75a87f7c5d42fbef1
+    url: https://github.com/autowarefoundation/transport_drivers.git
+    version: 39ebd8afe1bb9760a6cd6272e428468480f6de90
 
   lidartag:
     type: git


### PR DESCRIPTION
## Description

This PR freezes the Nebula version to v0.0.1 (equivalent to the current main branch). The transport_drivers dependency is updated to reflect the move to the autowarefoundation repo.

See
- https://github.com/autowarefoundation/autoware/pull/5271
- https://github.com/tier4/pilot-auto/pull/962

for details.

## Tests performed

Not applicable.

## Effects on system behavior

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
