### PR TITLE
fix: fix rosdep error by adding EagleEye dependencies to repos file

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -113,5 +113,11 @@ repositories:
     type: git
     url: https://github.com/MapIV/eagleye.git
     version: autoware-main
-
-
+  universe/external/rtklib_ros_bridge:
+    type: git
+    url: https://github.com/MapIV/rtklib_ros_bridge.git
+    version: ros2-v0.1.0
+  universe/external/llh_converter:
+    type: git
+    url: https://github.com/MapIV/llh_converter.git
+    version: ros2


### PR DESCRIPTION
## Description

Fix for:
- #23 

Added missing EagleEye dependencies to `autoware.repos`.

## Tests performed

Build Edge.Auto from scratch and confirm the rosdep issue is gone.

## Effects on system behavior

It will build again whereas in the current revision it does not seem to.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
